### PR TITLE
[#49] Unify app version format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This document outlines major changes between releases.
 
 ## [Unreleased]
 
+### Changed
+- Unify application version format (#49) 
+
 ## [0.3.0] "Thunder Bluff" - 2022-08-15
 
 ### Added 

--- a/cmd/neofs-rest-gw/config.go
+++ b/cmd/neofs-rest-gw/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -161,7 +162,7 @@ func config() *viper.Viper {
 
 		os.Exit(0)
 	case version != nil && *version:
-		fmt.Printf("NeoFS REST Gateway %s\n", Version)
+		fmt.Printf("NeoFS REST Gateway\nVersion: %s\nGoVersion: %s\n", Version, runtime.Version())
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
Version output now:
```
NeoFS REST Gateway
Version: v0.3.0-dirty
GoVersion: go1.18.3
```

Signed-off-by: Denis Kirillov <denis@nspcc.ru>