### PR TITLE
workflows: drop private DCO, reuse org-wide one

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -6,16 +6,5 @@ on:
       - master
 
 jobs:
-  commits_check_job:
-    runs-on: ubuntu-latest
-    name: Commits Check
-    steps:
-    - name: Get PR Commits
-      id: 'get-pr-commits'
-      uses: tim-actions/get-pr-commits@master
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-    - name: DCO Check
-      uses: tim-actions/dco@master
-      with:
-        commits: ${{ steps.get-pr-commits.outputs.commits }}
+  dco:
+    uses: nspcc-dev/.github/.github/workflows/dco.yml@master


### PR DESCRIPTION
Private copy is not the best option for it.