### PR TITLE
Fix `upload` to handle attributes `FilePath`, `FileName`

### DIFF
--- a/gen/restapi/embedded_spec.go
+++ b/gen/restapi/embedded_spec.go
@@ -1008,6 +1008,18 @@ func init() {
             "description": "The file to upload.  If no file is present in this field, any other field name will be accepted, except for an empty one.",
             "name": "payload",
             "in": "formData"
+          },
+          {
+            "type": "string",
+            "description": "This attribute, in any combination of upper/lower case, will be added to the object as the ` + "`" + `FileName` + "`" + ` attribute. It will also be returned as the ` + "`" + `FileName` + "`" + ` attribute in GET/HEAD API calls for the object (/get/{containerId}/{objectId}) and the ` + "`" + `name` + "`" + ` in POST call search in a container (/objects/{containerId}/search).",
+            "name": "X-Attribute-Filename",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "description": "This attribute, in any combination of upper/lower case, will be added to the object as the ` + "`" + `FilePath` + "`" + ` attribute. It will also be returned as the ` + "`" + `FilePath` + "`" + ` attribute in GET/HEAD API calls for the object (/get/{containerId}/{objectId}) or the ` + "`" + `filePath` + "`" + ` in POST call search in a container (/objects/{containerId}/search).",
+            "name": "X-Attribute-Filepath",
+            "in": "header"
           }
         ],
         "responses": {
@@ -3312,6 +3324,18 @@ func init() {
             "description": "The file to upload.  If no file is present in this field, any other field name will be accepted, except for an empty one.",
             "name": "payload",
             "in": "formData"
+          },
+          {
+            "type": "string",
+            "description": "This attribute, in any combination of upper/lower case, will be added to the object as the ` + "`" + `FileName` + "`" + ` attribute. It will also be returned as the ` + "`" + `FileName` + "`" + ` attribute in GET/HEAD API calls for the object (/get/{containerId}/{objectId}) and the ` + "`" + `name` + "`" + ` in POST call search in a container (/objects/{containerId}/search).",
+            "name": "X-Attribute-Filename",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "description": "This attribute, in any combination of upper/lower case, will be added to the object as the ` + "`" + `FilePath` + "`" + ` attribute. It will also be returned as the ` + "`" + `FilePath` + "`" + ` attribute in GET/HEAD API calls for the object (/get/{containerId}/{objectId}) or the ` + "`" + `filePath` + "`" + ` in POST call search in a container (/objects/{containerId}/search).",
+            "name": "X-Attribute-Filepath",
+            "in": "header"
           }
         ],
         "responses": {

--- a/gen/restapi/operations/upload_container_object_parameters.go
+++ b/gen/restapi/operations/upload_container_object_parameters.go
@@ -40,6 +40,14 @@ type UploadContainerObjectParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
+	/*This attribute, in any combination of upper/lower case, will be added to the object as the `FileName` attribute. It will also be returned as the `FileName` attribute in GET/HEAD API calls for the object (/get/{containerId}/{objectId}) and the `name` in POST call search in a container (/objects/{containerId}/search).
+	  In: header
+	*/
+	XAttributeFilename *string
+	/*This attribute, in any combination of upper/lower case, will be added to the object as the `FilePath` attribute. It will also be returned as the `FilePath` attribute in GET/HEAD API calls for the object (/get/{containerId}/{objectId}) or the `filePath` in POST call search in a container (/objects/{containerId}/search).
+	  In: header
+	*/
+	XAttributeFilepath *string
 	/*Base58 encoded container id.
 	  Required: true
 	  In: path
@@ -68,6 +76,14 @@ func (o *UploadContainerObjectParams) BindRequest(r *http.Request, route *middle
 		}
 	}
 
+	if err := o.bindXAttributeFilename(r.Header[http.CanonicalHeaderKey("X-Attribute-Filename")], true, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.bindXAttributeFilepath(r.Header[http.CanonicalHeaderKey("X-Attribute-Filepath")], true, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	rContainerID, rhkContainerID, _ := route.Params.GetOK("containerId")
 	if err := o.bindContainerID(rContainerID, rhkContainerID, route.Formats); err != nil {
 		res = append(res, err)
@@ -86,6 +102,40 @@ func (o *UploadContainerObjectParams) BindRequest(r *http.Request, route *middle
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// bindXAttributeFilename binds and validates parameter XAttributeFilename from header.
+func (o *UploadContainerObjectParams) bindXAttributeFilename(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.XAttributeFilename = &raw
+
+	return nil
+}
+
+// bindXAttributeFilepath binds and validates parameter XAttributeFilepath from header.
+func (o *UploadContainerObjectParams) bindXAttributeFilepath(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.XAttributeFilepath = &raw
+
 	return nil
 }
 

--- a/handlers/objects.go
+++ b/handlers/objects.go
@@ -42,6 +42,9 @@ const (
 	attributeFilePath         = "FilePath"
 	sizeToDetectType          = 512
 	userAttributeHeaderPrefix = "X-Attribute-"
+
+	attributeFilepathHTTP = "Filepath"
+	attributeFilenameHTTP = "Filename"
 )
 
 type readCloser struct {

--- a/handlers/objects.go
+++ b/handlers/objects.go
@@ -39,7 +39,6 @@ import (
 )
 
 const (
-	attributeFilePath         = "FilePath"
 	sizeToDetectType          = 512
 	userAttributeHeaderPrefix = "X-Attribute-"
 
@@ -645,7 +644,7 @@ func headObjectBaseInfo(ctx context.Context, p *pool.Pool, cnrID cid.ID, objID o
 		switch attr.Key() {
 		case object.AttributeFileName:
 			resp.Name = attr.Value()
-		case attributeFilePath:
+		case object.AttributeFilePath:
 			resp.FilePath = attr.Value()
 		}
 	}

--- a/handlers/util.go
+++ b/handlers/util.go
@@ -291,6 +291,7 @@ func filterHeaders(l *zap.Logger, header http.Header) (map[string]string, error)
 			continue
 		}
 
+		clearKey = formatSpecialAttribute(clearKey)
 		result[clearKey] = value
 
 		l.Debug("add attribute to result object",
@@ -298,4 +299,18 @@ func filterHeaders(l *zap.Logger, header http.Header) (map[string]string, error)
 			zap.String("value", value))
 	}
 	return result, nil
+}
+
+// formatSpecialAttribute checks if a key-string is one of the special NEOFS
+// attributes and returns the string in the correct case.
+// For example: "Filepath" -> "FilePath".
+func formatSpecialAttribute(s string) string {
+	switch s {
+	case attributeFilepathHTTP:
+		return attributeFilePath
+	case attributeFilenameHTTP:
+		return object.AttributeFileName
+	default:
+		return s
+	}
 }

--- a/handlers/util.go
+++ b/handlers/util.go
@@ -307,7 +307,7 @@ func filterHeaders(l *zap.Logger, header http.Header) (map[string]string, error)
 func formatSpecialAttribute(s string) string {
 	switch s {
 	case attributeFilepathHTTP:
-		return attributeFilePath
+		return object.AttributeFilePath
 	case attributeFilenameHTTP:
 		return object.AttributeFileName
 	default:

--- a/handlers/util_test.go
+++ b/handlers/util_test.go
@@ -191,16 +191,24 @@ func TestFilter(t *testing.T) {
 	req.Set("X-Attribute-Neofs-Expiration-Epoch1", "101")
 	req.Set("X-Attribute-NEOFS-Expiration-Epoch2", "102")
 	req.Set("X-Attribute-neofs-Expiration-Epoch3", "103")
+	req.Set("X-Attribute-FileName", "FileName") // This one will be overridden.
+	req.Set("X-Attribute-filename", "filename")
+	req.Set("X-Attribute-fIlePaTh", "fIlePaTh/") // This one will be overridden.
+	req.Set("X-Attribute-Filepath", "Filepath/")
+	req.Set("X-Attribute-FilePath1", "FilePath/1")
 	req.Set("X-Attribute-My-Attribute", "value")
 	req.Set("X-Attribute-MyAttribute", "value2")
-	req.Set("X-Attribute-Empty-Value", "")
-	req.Set("X-Attribute-", "prefix only")
-	req.Set("No-Prefix", "value")
+	req.Set("X-Attribute-Empty-Value", "") // This one will be skipped.
+	req.Set("X-Attribute-", "prefix only") // This one will be skipped.
+	req.Set("No-Prefix", "value")          // This one will be skipped.
 
 	expected := map[string]string{
 		"__NEOFS__EXPIRATION_EPOCH1": "101",
 		"__NEOFS__EXPIRATION_EPOCH2": "102",
 		"__NEOFS__EXPIRATION_EPOCH3": "103",
+		"FileName":                   "filename",
+		"FilePath":                   "Filepath/",
+		"Filepath1":                  "FilePath/1",
 		"My-Attribute":               "value",
 		"Myattribute":                "value2",
 	}

--- a/spec/rest.yaml
+++ b/spec/rest.yaml
@@ -644,6 +644,16 @@ paths:
           required: false
           type: file
           description: The file to upload.  If no file is present in this field, any other field name will be accepted, except for an empty one.
+        - name: X-Attribute-Filename
+          in: header
+          required: false
+          type: string
+          description: This attribute, in any combination of upper/lower case, will be added to the object as the `FileName` attribute. It will also be returned as the `FileName` attribute in GET/HEAD API calls for the object (/get/{containerId}/{objectId}) and the `name` in POST call search in a container (/objects/{containerId}/search).
+        - name: X-Attribute-Filepath
+          in: header
+          required: false
+          type: string
+          description: This attribute, in any combination of upper/lower case, will be added to the object as the `FilePath` attribute. It will also be returned as the `FilePath` attribute in GET/HEAD API calls for the object (/get/{containerId}/{objectId}) or the `filePath` in POST call search in a container (/objects/{containerId}/search).
       responses:
         200:
           headers:


### PR DESCRIPTION
When we receive headers, they are automatically formatted from any case to
only the first letter being uppercase. For example, `FilePath` transforms into
`Filepath`. However, NEOFS is case-sensitive for these attributes, which is why
we intentionally change them to CamelCase style. We hope this is a temporary
workaround and will be removed asap.
Connected to https://github.com/nspcc-dev/neofs-http-gw/issues/255.

Also redundant constant `attributeFilePath` is removed.
