### PR TITLE
spec: remove extra producers from `get`&`get_by_attribute`

### DIFF
--- a/gen/restapi/doc.go
+++ b/gen/restapi/doc.go
@@ -15,9 +15,7 @@
 //
 //  Produces:
 //    - application/octet-stream
-//    - image/jpeg
 //    - application/json
-//    - text/plain
 //
 // swagger:meta
 package restapi

--- a/gen/restapi/embedded_spec.go
+++ b/gen/restapi/embedded_spec.go
@@ -535,10 +535,7 @@ func init() {
           }
         ],
         "produces": [
-          "application/octet-stream",
-          "application/json",
-          "image/jpeg",
-          "text/plain"
+          "application/octet-stream"
         ],
         "summary": "Get object by container ID and object ID. Also returns custom users' header attributes ` + "`" + `X-Attribute-*` + "`" + `. It returns the MIME type based on headers or object contents, so the actual Content-Type can differ from the list in the \"Response content type\" section.",
         "operationId": "getContainerObject",
@@ -615,10 +612,7 @@ func init() {
           }
         ],
         "produces": [
-          "application/octet-stream",
-          "application/json",
-          "image/jpeg",
-          "text/plain"
+          "application/octet-stream"
         ],
         "summary": "Find and get an object (payload and attributes) by a specific attribute. If more than one object is found, an arbitrary one will be returned. It returns the MIME type based on headers or object contents, so the actual Content-Type can differ from the list in the \"Response content type\" section.",
         "operationId": "getByAttribute",
@@ -2592,10 +2586,7 @@ func init() {
           }
         ],
         "produces": [
-          "application/json",
-          "application/octet-stream",
-          "image/jpeg",
-          "text/plain"
+          "application/octet-stream"
         ],
         "summary": "Get object by container ID and object ID. Also returns custom users' header attributes ` + "`" + `X-Attribute-*` + "`" + `. It returns the MIME type based on headers or object contents, so the actual Content-Type can differ from the list in the \"Response content type\" section.",
         "operationId": "getContainerObject",
@@ -2764,10 +2755,7 @@ func init() {
           }
         ],
         "produces": [
-          "application/json",
-          "application/octet-stream",
-          "image/jpeg",
-          "text/plain"
+          "application/octet-stream"
         ],
         "summary": "Find and get an object (payload and attributes) by a specific attribute. If more than one object is found, an arbitrary one will be returned. It returns the MIME type based on headers or object contents, so the actual Content-Type can differ from the list in the \"Response content type\" section.",
         "operationId": "getByAttribute",

--- a/gen/restapi/operations/neofs_rest_gw_api.go
+++ b/gen/restapi/operations/neofs_rest_gw_api.go
@@ -45,7 +45,6 @@ func NewNeofsRestGwAPI(spec *loads.Document) *NeofsRestGwAPI {
 
 		BinProducer:  runtime.ByteStreamProducer(),
 		JSONProducer: runtime.JSONProducer(),
-		TxtProducer:  runtime.TextProducer(),
 
 		AuthHandler: AuthHandlerFunc(func(params AuthParams) middleware.Responder {
 			return middleware.NotImplemented("operation Auth has not yet been implemented")
@@ -173,14 +172,10 @@ type NeofsRestGwAPI struct {
 
 	// BinProducer registers a producer for the following mime types:
 	//   - application/octet-stream
-	//   - image/jpeg
 	BinProducer runtime.Producer
 	// JSONProducer registers a producer for the following mime types:
 	//   - application/json
 	JSONProducer runtime.Producer
-	// TxtProducer registers a producer for the following mime types:
-	//   - text/plain
-	TxtProducer runtime.Producer
 
 	// BearerAuthAuth registers a function that takes a token and returns a principal
 	// it performs authentication based on an api key Authorization provided in the header
@@ -326,9 +321,6 @@ func (o *NeofsRestGwAPI) Validate() error {
 	}
 	if o.JSONProducer == nil {
 		unregistered = append(unregistered, "JSONProducer")
-	}
-	if o.TxtProducer == nil {
-		unregistered = append(unregistered, "TxtProducer")
 	}
 
 	if o.BearerAuthAuth == nil {
@@ -483,12 +475,8 @@ func (o *NeofsRestGwAPI) ProducersFor(mediaTypes []string) map[string]runtime.Pr
 		switch mt {
 		case "application/octet-stream":
 			result["application/octet-stream"] = o.BinProducer
-		case "image/jpeg":
-			result["image/jpeg"] = o.BinProducer
 		case "application/json":
 			result["application/json"] = o.JSONProducer
-		case "text/plain":
-			result["text/plain"] = o.TxtProducer
 		}
 
 		if p, ok := o.customProducers[mt]; ok {

--- a/spec/rest.yaml
+++ b/spec/rest.yaml
@@ -589,9 +589,6 @@ paths:
         - CookieAuth: [ ]
       produces:
         - application/octet-stream
-        - application/json
-        - image/jpeg
-        - text/plain
       parameters:
         - name: download
           in: query
@@ -679,9 +676,6 @@ paths:
         - CookieAuth: [ ]
       produces:
         - application/octet-stream
-        - application/json
-        - image/jpeg
-        - text/plain
       parameters:
         - name: download
           in: query


### PR DESCRIPTION
We actually always use only 1 producer `application/octet-stream`. However, they return the MIME type based on headers or object contents, so the actual `Content-Type` can differ from the list in the "Response content type" section.

Close https://github.com/nspcc-dev/neofs-rest-gw/issues/143.