### PR TITLE
*: Serve HEAD requests for documentation URLs

### DIFF
--- a/cmd/neofs-rest-gw/main.go
+++ b/cmd/neofs-rest-gw/main.go
@@ -76,8 +76,13 @@ func main() {
 	e := echo.New()
 	e.HideBanner = true
 	e.StaticFS(docsURL, docs.FS)
+	e.Add(http.MethodHead, docsURL+"*", echo.StaticDirectoryHandler(docs.FS, false))
+
 	e.GET(swaggerURL, swaggerDocHandler)
+	e.HEAD(swaggerURL, swaggerDocHandler)
+
 	e.GET("/", redirectHandler)
+	e.HEAD("/", redirectHandler)
 
 	e.Group(baseURL, middleware.OapiRequestValidator(swagger))
 	apiserver.RegisterHandlersWithBaseURL(e, neofsAPI, baseURL)


### PR DESCRIPTION
Previously, URLS: "/", "/v1/docs/", "/v1/docs/swagger.json" returned the error "405 Method Not Allowed". But now they return the same headers as GET requests.

Close #197.