### PR TITLE
*: Add GET and OPTIONS requests for `network_info`

### DIFF
--- a/handlers/apiserver/rest-server.gen.go
+++ b/handlers/apiserver/rest-server.gen.go
@@ -264,6 +264,18 @@ type HeaderType string
 // MatchType Match type in NeoFS EACL filter.
 type MatchType string
 
+// NetworkInfoOK Network information from NeoFS.
+type NetworkInfoOK struct {
+	AuditFee                   uint64 `json:"auditFee"`
+	ContainerFee               uint64 `json:"containerFee"`
+	EpochDuration              uint64 `json:"epochDuration"`
+	HomomorphicHashingDisabled bool   `json:"homomorphicHashingDisabled"`
+	MaxObjectSize              uint64 `json:"maxObjectSize"`
+	NamedContainerFee          uint64 `json:"namedContainerFee"`
+	StoragePrice               uint64 `json:"storagePrice"`
+	WithdrawalFee              uint64 `json:"withdrawalFee"`
+}
+
 // ObjectBaseInfo Basic object information.
 type ObjectBaseInfo struct {
 	// Address Address of the object in NeoFS.
@@ -689,6 +701,12 @@ type ServerInterface interface {
 
 	// (OPTIONS /get_by_attribute/{containerId}/{attrKey}/{attrVal})
 	OptionsByAttribute(ctx echo.Context, containerId ContainerId, attrKey AttrKey, attrVal AttrVal) error
+	// Get network settings
+	// (GET /network-info)
+	GetNetworkInfo(ctx echo.Context) error
+
+	// (OPTIONS /network-info)
+	OptionsNetworkInfo(ctx echo.Context) error
 
 	// (OPTIONS /objects)
 	OptionsObjectsPut(ctx echo.Context) error
@@ -1396,6 +1414,24 @@ func (w *ServerInterfaceWrapper) OptionsByAttribute(ctx echo.Context) error {
 	return err
 }
 
+// GetNetworkInfo converts echo context to params.
+func (w *ServerInterfaceWrapper) GetNetworkInfo(ctx echo.Context) error {
+	var err error
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetNetworkInfo(ctx)
+	return err
+}
+
+// OptionsNetworkInfo converts echo context to params.
+func (w *ServerInterfaceWrapper) OptionsNetworkInfo(ctx echo.Context) error {
+	var err error
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.OptionsNetworkInfo(ctx)
+	return err
+}
+
 // OptionsObjectsPut converts echo context to params.
 func (w *ServerInterfaceWrapper) OptionsObjectsPut(ctx echo.Context) error {
 	var err error
@@ -1877,6 +1913,8 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.GET(baseURL+"/get_by_attribute/:containerId/:attrKey/:attrVal", wrapper.GetByAttribute)
 	router.HEAD(baseURL+"/get_by_attribute/:containerId/:attrKey/:attrVal", wrapper.HeadByAttribute)
 	router.OPTIONS(baseURL+"/get_by_attribute/:containerId/:attrKey/:attrVal", wrapper.OptionsByAttribute)
+	router.GET(baseURL+"/network-info", wrapper.GetNetworkInfo)
+	router.OPTIONS(baseURL+"/network-info", wrapper.OptionsNetworkInfo)
 	router.OPTIONS(baseURL+"/objects", wrapper.OptionsObjectsPut)
 	router.PUT(baseURL+"/objects", wrapper.PutObject)
 	router.OPTIONS(baseURL+"/objects/:containerId/search", wrapper.OptionsObjectsSearch)
@@ -1892,130 +1930,133 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+x92XLbuNLwq6D4/1VJzpEsWV7jqrmQZdlWvFtyMp4kdQYiIQpjEmAA0LKS8rt/hYU7",
-	"KVEZe5bEuYlFYml0Nxq9ofnNsqkfUIKI4NbeNyuADPpIIKZ+QSHYCZrLPx3EbYYDgSmx9qyL8R/IFkC+",
-	"x+NQIHCH5kBQwBFk9nTNalhYNgugmFoNi0AfWXvxaA2LoS8hZsix9gQLUcPi9hT5UE4j5oFsygXDxLUe",
-	"Hxuq13vo1YDhHnohklD4UCwEQg63GhA2JQJigtjAKQKyDzna2gWI2NRBDojbAuxUAJEebjVAJqHn7SPI",
-	"EBvRO0SKwFwyeo8lGGPVCgjZDGAOJphAD1AGXCgQ4FMaeg6AnCN/7CGABQg5Ji7g2CVQhAzFoH8JEZsn",
-	"sCcQWGlQHTSBoSesvQn0OGpEoI8p9RAkCnaqCFYDg7phNfrigVbDXby0EzS/lHxeBOQYPcRQiCkCQTj2",
-	"sA0CyASgE/VIcfoUCoUp0yyN6xjmKYKOQpKB+temRltzGMHR1LuhFswVAEvMbW/GMMfNwYSy7wWrLkhD",
-	"2QgVYbrhCMyg5yEh9wKRpEzgUiMjyYcECnyPwDmih8PlbKcH7OnxVuO8R8kmPKCEIyXVtODoUSIQERcn",
-	"8pGtf8g//9P6j/wvGX9CmQ+FHBETqEDK4+SxUSqa5FI0ttW0XdtGnDflvIx6za7n0VnzgmEXk+yERZQb",
-	"WJsHmAeUYz1LvS6niLhiWrf1SL1Z3PYUctE8ow6eYOQsa/xrsxvJ5+Yh9tA59NEqfUbYR1xAPyjthIlA",
-	"LmKmVy+Sqs1BDbg0jeo1ndUZVLbVgx4j6DwjXwFMJvSFuX4y5nqMZJ6hd0SnLIdchx4C6AHZoXwAGOKh",
-	"JwBUrQEmRtr2u73TNdDHYooYgJJXuJTIDiIYcQAVLwGszzsWeuiVVB88qRUmuhUioW/tfbS6p6cXH6yG",
-	"ddA/v7U+F5i4YXUdhyHOi7CaF9HBGp36Bkg1xwP0Aw9FOynWwKyt499GZOvL3TXx3eHXt+6QzTqdXt+5",
-	"vLzbJlfTu9mkc+Z+nd/f4bt7K615WLvnG3TnQLDt0fqDQD2xja5n08B/t/Nuetbf2j2eh+vOPeSzcHTg",
-	"SOgDRgPEBNZHR04PLKw1reIUiZ0oKx9zKmDcL0GgfpRC4CFlN4FHofNUmPwf/m5U6q5PhEs1WCUyy99W",
-	"YVO2TvcsxWckAEoQGRsTmAMIAoiZRKqelWu9z4YEjJG0O6A9lQogBTCl9FMGIDEkyGH+TppSUj1izQM0",
-	"wQQ5zRF0rYalLBdrzxLQ1VZMEVt32gwrIMl0XYagO6Vp6sZlONmHHiS2Gig7L0x2b2HugCEbcyOH4uMs",
-	"xERsdJLjLJajtYGN5kzPsBB4bY4UleO0CaRohzlADwGyhabbWOnJPnIyhPr4LVI6/XlT69BNNUbMWaoN",
-	"tCOmMRLQiEhr7+PnhiVxCE2Do/5IogMyF0kr+6OipmnHqJzSuhgd96+H1uPnx8+PjdTekIu6R2wsLbub",
-	"kVxsDFq0LgpshqRNl3R6/Fy52eSP/8/QxNqz/l8rsf1b5mxpyQMkmSZPqYb10HRpUz5s8jscNKnCNfSa",
-	"AZV0ZtoOe0wQ9c3CAvl86bTIpkwJCTMhZAzOC5xhRi1lAqVF1WIFaRsZGRmTiccMwlDAEEdE8ggmQGtn",
-	"ik9y21nzxJ7Vmw5ODrq0e+S6g+51d3/gDgbdB9rrHV0Nf3PptPvfd1t/HH44PMMXwfz+7Lf98O1sdjk6",
-	"4R/4UftLp7199x5tb+Dww2Vr1r/r9zeHg/ftK+KSkyA4mGxtXqGvNyc+ZDs3V+P59vHXcDLamr8fXNz/",
-	"sXPV//IbuYD37ORD2572UG922b6bOrD1x9u7dtsW2+dn/YOHq8MP/3V/+aUoVES5DyFnVObNyMWbV49Z",
-	"RqFYhRqQCS3OKp9KESI1FTimoUgYOod4mAjwj5FUTXS5RJyub2/u7q632zsdS24q3VApiUmb7KYZQ47t",
-	"ru1Ze1sbne2tTntjvfHnVI+483nO9SOFySwa9Hx8446Gh/eXPr9+8I/QhyAMj9C7G3pN8fZln9lnUhh6",
-	"0EY+IuKSetiWa7nuXwIpae8R02LY6qytrxfpHCOM196QySFZ2JNpNJWcCjYkBDnmbZbEoykCE4YRcbw5",
-	"kBJGbUXlQTEjgglGnlPCZY2lulcO02UKxay6dwG5ZWdthOalB1iC7xSyGjmlLwtwAl4RmGTqhfvqFHNR",
-	"RLp8KpWYeDquDMgKpVCfTy87bNkOK8dR1dI7ddd+yPs7x6dX+/u3dufD4buv4ejXMzvgwUHfn9088IOt",
-	"W/983GGdrfAmXLT2zlMtfr1k8Z8bFsdfkbXXqVbq60ua7LFQIm30XKV2eakNIDed6rNws1yGovwc+hS2",
-	"2xt2oP5D1+hLiLgAY+rMy1StNTCigAfIxpN5yghQsi3kCMBA4odh2clgag5eq9dB5KnHJAlicDDDnicV",
-	"U+wSypDzZi0DzyeS+TmKIUqbIHMaAj/kIpoC6D7yNNfdLrOk1q9byXsAiVPotK+4t3daaG0gbCUgGiCn",
-	"W7npQJCeL3qdW1O+deSgkKuytX8LzKaIaSindKYOkGT1r+VjLLhR8d5InY4Lics1cEgZMFKvoQacQSJU",
-	"4Eo2ABvApgFGypBG94jNzRgNwKmeHxJFVjnjhEq4MHENnHsFNOhVMYOmPD7l7tooIDMaJO6VRY7+AcGU",
-	"ockvn6ypEAHfa7VcLKbheM2mfovwwLabDrpvEUQnvCmZszX26LjlQy4Qa7XXm5DZ01a709SAr/nOJ831",
-	"6ExiQStfGVLBmpRWPAISJqkgcdwsMrOT8EpCRy5YaIuQoQbQFFWNvRmcc8P0DuDYDz0BCaIh9+ZghsU0",
-	"O8oaGElWmVA5jB6CSMoCHmoDQFrvZA7sKSQu4mtgoKcBG53mWLbXwkaPDIF8pDQUuWmzTKCV1yomSFMP",
-	"+y7gzE6Rj8HZmiZhyBEzTuNqarY3t9F2Z8OxO87u+sYmHHfGu1sTG052N9bbOzvO1s7m1vY67MSkDrDd",
-	"grbXVAdQM2D4Hgq0xu/dTxaAnvjlkyVpoagScUIVpQUcezFrAgCMmBBTBJ3049Qrln+e7qbfDef+mHpm",
-	"zujhog5nCBJM3BV6HCRCvrJX9IIVF9gqrNAML0+G71i4GWo/Gt2p0VbZYSt06GrBqQO7sjdQQWO18Vjo",
-	"IS65nyF18AMUP62coRQ9q633ZgXwb/hKq5XGhVJ5iqIEO4gIFVIA43k6sHuH5sDD5E67gzKdnhMLwxWW",
-	"NZxzgfwVOgyIXPK1pDkkTouytF5CHcQj2WWHjMlj1qh3Em0EiRlld8CHwRoYXJv28tSjxJuDADEp5gqq",
-	"wRES11J+HkM+LZxojULz42gnZZuVKR1DlVBSVFAIshHnxjEDHCgggKGDxRro5RYbA+9IAis3bqQ1xtan",
-	"3APYVq6Hteek+8UKZLwQU8T4Ch16HpZ6tfZjORQQKnS0Rh1w0Z6AArmUqTDPmN6j51zt4QrAH2ICvVXa",
-	"e9AFDiJzyeb9B4GI1KRVWGswARyJBkiUDHuK7Ls4B6aRaS8fG1X7OXHx6yo7XmD7bv69yHDwZILUvlbC",
-	"MA4KMWPJyF2WBIkSdCVBo4K1EIriBoyGU3bGFN4jQEnR0FDBzXLzYoyiDJpYa+PSLEoyQSRokokVeKm4",
-	"lppyLEU1Y/L3OIyDMnSimX0WqX5GCEyg5xklrShiboej/lnJCqmHAGQIoAcbBdpHPGHUl1KEq5NS2xNi",
-	"inwN31grmIadnlWStFdgjwNE5qs1VyZQ5BmPGCh1iBopMn/OFa6vquisrhg9/RKjh2mlMHqWVpzzRnyo",
-	"AruGwXlsbaSDFnMapk/yZN+Z0MZYmrwciRIjN7Ja85zffmgf7h/uHx4eFrmfMhAw5OgwZaEnktaE1qGa",
-	"DEGnOWNYoOIoyhHG1xYaRV2P0wZwKHkl5P50kTbIkcg4T5R6qtRVLhi2RQ4fazXsrqexmnea0PbKTebE",
-	"7q2ylyviGDzlQuyFXFA/yVJJuRNNaDjjSbQKVFjiEi138208c9CgfuCwOrZQf4wloYD6Ay2NCtQd6rHE",
-	"FdmHZTGSvmR0naajRMZT5sEwFWXl2fC1jk4nwetvJq9Mp2tZF/vv+j3ZQrNnnGfVsJRyaVoNR9eD86P/",
-	"9a9uuqcpjvXnE+xplk0HxKOIeTokXhYIXzH7Jl7e0wado2Gzvvoy53KfMcquTa7pEs+yaguixNTF8isl",
-	"Y0y6rIAi5EBK2ljCT7C0n0h0CP0paddpN2GAm/edlp4pJe+miKGVpJwE0tpbb3c2G5YvjTZXe/ElQTwk",
-	"YrXu8mYkrfN4yyUxwO7loCx9yEG18k7q7/YYuhLeEiZ5cRE/KZKqDZFnoWhkM04l70QpkjmRoFhF9lgD",
-	"SnUBDhKI+ZggwGnIbBQpMEi2TGfnHcltJvFXlpl3qPZ8cT79PJsuqIIfyo4KIBPYDj3IQEKRvJVhDOvS",
-	"NKjvFy/nF6NKEZPnj/Qsi8l2nLR8bFQmWqXAWTzcWdywfsZTCtiGydVK5luU+nScWWWObUjopxTcgHKO",
-	"x17EMopkurvyA8Ig8OZxmmc2VTTFUNf9q5v+UBIsptywf/1+0OuXsthZGmtZ8NQrxdU5TtMwpCfNnS4F",
-	"biibWafg7kOOysN82j1Ak4xqk3uSzzVJ8t/+rhRUyd+XUEytPavlz1t6pBaBPloTDyK5IhE/KapyySIW",
-	"qm+mWWbOkq1QnhtWlcVXxraaOOWEuVhKkidMTohA+tz4e8i7YpT+2TN7/kSCc/RyaML1pVSdhJ4HAjhX",
-	"5q4K0jeyJ/j2Zmnm6MLUHT3c0jw2s9ej5o3KkcpXcJmCWkqsSHVLr6BqAYvygyoywTPozCQHpYCs3luL",
-	"c4GMoyG3scxTbR78/XLPiLWczNO5N08P3cbR2D/7EHL4wT07pncfQtz5ehCSh7PR1/1QhFdn70/H4nTD",
-	"PiC7vBw6Tn3UomKKmAF0QZ5MjOqamzZ3mn1/lkw08YIUGT1X1V2DOukxRu1baNOkUleidPnliSspYtdL",
-	"WpkYfbIkaYV0HQdrS8CbJ46yqqnNtitO+3qcFTMOFPBNKTDJtl+eQwMq/+XdZ+krC3do3tTXoFVILEpp",
-	"1ukviaM98v2foLkCVHeJ/OqYgJvRYXPXpDSoFuodoeo98gMxrw1wDtz30MNOku9UkS8Resmw+omHy7No",
-	"zuYxAvbAK7kF9WpeVWXWxANFjtn0XDUXMSD3z7qMZwVe+1uz2UyYp+7RCwomIVN3w8y+1Nf6MXG/x6Gp",
-	"7ruUuTMlsZqJT/NPCfJJfP3P8ufSiDSqcawbWLedt6Fz9D50evv3v+F9H3548P4xTs9latckdbtxkf6z",
-	"yp2zeMzSMyDx1hWuGGqZ/yodP1FWXFR5IWfOpe4RqtSqQMXapSGqbk6l3AnGeZDxXyjn5HG/e2A11A2Y",
-	"hnXQP+2P+sru7F73jq2Gdd09P+pH/x93h8elBuFlKOLcAH0792ncqiu6KRfQpIwQxkdZvKkGOCauh9KY",
-	"VjHJ3I58nktKhW0TX0dduFN0q8cUFDX3mPFUlag9NM2oCzWouOFjapk15x+p9ks9xQYNyfrS8CWzltKZ",
-	"eiU2h3yqs1RUV7mz8g6Zm2H/Wm4GFcW2GhGRGtZJ/3ZYuhHUFa/CVEneDEdc5QPpuGMJU2U3y/Yf9yfv",
-	"eldsG23u3D7sDvl4eL4xOXe/Mnrz7v3d7fb21dvZl4dbu/uHrZPJx9ZetItX9vHr7oup9V62ydNGdSzD",
-	"vE4xqvKF6rfGJ6WORkycCvup3IUZubqGag39L6GqPpN1QDSNZVPz0qcZdzEWNORq6pUviuoJFjke01jj",
-	"1YZmuhlAnnLs59GWDj0tRmGP+j4llwxN8ENOkWgF+mni6dGB1LTiUYMcArqxSlIgx6pSK8NZy2RHNHg1",
-	"ss8iqpdyqB+7U9PSoWSpqUfnVGSenlNxqe8+Rk8yGC8TJsNQVQuoDnqZBkmkK0t8rl8nEdcMxuO338oK",
-	"CqXRF7UsQ5+R3sXraDDKNtDOb6mmxOco6Jl73lGq+CuuU4JsD3JVLgECz3B5kk3KEy3otRTAqsubopyQ",
-	"3G61O+uOvbU9sbed3XVna3cdop3t9hbcRe02aqP2GI637TF0tra34dvOJtzq7GxsvN3c2YJvd+Au2thV",
-	"W9Mczkrcl0mQLL9WBLaSA5WZg2hh4FS2KZEc8sBT/UupII+Taj7JOet8yPgUeioxVx5DryeZRFbKym/x",
-	"vsnf5I4v6Xq3J/tdt9fvtmGv6x70u33cdd0Dc2m3Zy7tDnrdwVUXD3q97plpN4jb7e+n292k2x1l2j1E",
-	"7Qbj3vRufbfzoX9wGHa/fNkgnLOjC3jcPj9p/zb9erg7Dv97e+ReDeC+27eKWEvfMu4FkAz23/WCd+G7",
-	"r5udkwv/6GxI+lN+cjT68CWEv3ZOv2wfTacXmxN4cXt3etCevP1w92t4+877sgn3u1Ny1D3Dg6t37qE9",
-	"6LvTq/0t78tG991vF+/5bEBm9vrgaOpd7Zz3bqabB4cXGzfd0aDf6/avule//JIAt+ieOakyUuKrxt8V",
-	"WVW8UxpZjS7mV8ZVk67F/S+tFjpJbjZHUtP0TtllpbLvvdFFsqPKpyYJVz0fI64ki7rGlKkPl9hPSsXL",
-	"Q1Ewd0ZS9yuB5LFhcWSHDIu5rsmlSKHzwrqhmC65Dh857yLPl3ITabMissjAWZxu9kr3fQX0gVtZV0xO",
-	"TBn+Giu/Rs4E+ATN9U08eofRQvhs1UQDpL1szbg6mwLdXJXhlVDoEYrTS5zh0vDTdX84At3LgaKJqVGm",
-	"nKmGVAl21sCNulmh3CeyR+RTUbY9tEUakzoPVbnSIIEuSl/HhVmNUmChJHoMiRohcw/zft3YPgQG2Nqz",
-	"Ntbaa+vK3SGmivgtaNs0JAITtzXWtT1a34zX/FE2KD0Qj5CQPYDpoY626JaiqehmxsgUl4n5WNkDR0hE",
-	"1UQamXqSH5eU/cvOUFW/Ma4NUr/03+dcAbhOu50rzmWcEhKu1h88XwBrkWSKllpSrWs/wWIea09UvEvO",
-	"ufmEi8nmL5UuyYlkQkbsaDcBD30fsrnmgZiJ4jUrjlWntIqAZJjmQr/4dzBOznC+uK5Dz+Pk/aKCYKV9",
-	"z5CYUuf7+tbjoxwt5e8WNKJ5GdGUCP9pMdWwAqpDrVnkGKws5GN1PQIMHPA6y8JvtP6groJz7OrrWjXL",
-	"eMb15FYqjlpQjdTx6uEJEthXexgFNFVUt3L6U9OlvETnertdFhwvJKBR5qdq9UDPAyFXd1mYvsulL25h",
-	"rorZLgfqkDJJ4+YNN9UB6hcP/azRiLjYp858JUlby0dgChYVvQNF2ZvS2ZSZGZUkypL58U8edvX8oRlb",
-	"rg7wuTq1KrU5qq2U2HrjnF6KEV/70c9KxeyZhacCcGYArmJJEncuIk3zsCkV96bhdc0WViy4W+O4EpZR",
-	"9bLiSc6aKZlVEFVli0+atHKVieUmrtsjrr+8SidTbfh5lbk0Qp6Gi38c9s0xrF50eql1FDx5KsYM9xPr",
-	"Vtk6OaU79BTzJGDJV1SJ9UX4VAX1XDntJJ3szygJUwRI6I/1lfuUQSso4Hc4AGNVeEPuE6bsSkGBTT1P",
-	"1d1QyeKqOi1HohLMyYSjinLf7YblY4L90Fd/L9cqEnB5EV6GRMhIFRwe9rFYoNL48EEDst5ut9OArZcA",
-	"tlyCFWpF16qfpFL+SnZyL1v463kl0kqgryKE1pYanF6h0FkdiZRg5zLUWZM/sykTlgiidOLEv0ZNaFR8",
-	"GEObDXFPvfVdzAVi+fpdmIDz8yHgiN1ju/LDBPK/JrdpgJquR8cqmPZU9sX3yYGostkiURCVAFzVdlgJ",
-	"olzGTQk8g+jCdVK0xVR2ytT+/PeKq1hA9XSuK0GzdF2axB24WLtPhVyy2kPrWyph4lFznId0aevsLj5Q",
-	"z79/I6cTM1bZkP8482AlkufD2yVEN00moQcU7s2FlR+AZzXLpPh1PAdYpeaXKqxHSDwRez2XhlRPLP6w",
-	"ClIJIetrR0dIaH54FtL+dGZfVnC3kKkFsHRjqRDwP2lzqSoGC/eUzgLOXuf7wfeXWvJ3bLJno+6L9fI0",
-	"m+cfrvg8iSFRtaP15ex0Gtbac1sQq6lfCsAwcKDAxP1BdLBhlVxZZjIgTcWG1XKRyJ0236J7j4+1zpyL",
-	"KB3qWTdOfBezaLtLJEjjsORTZUDTGEBuvsijKkenrueugZG0+H14p8s2jxmdcW34O3RGUnW35BgT7EnD",
-	"nwskH08An+rqvlgAqsOwAXQrfQHRgBkXQJyNaK03gGiAUQMoTysYXd/0G2Ck/p43wBzxBrhtgNv+sAFu",
-	"1dXgmvkIZYiN27XynztcGkigtkCiyQVD+ouTz8LkEojNvx6IcyrAhIbEKZzm3yTbpXPmPqov8aSz1D5+",
-	"fiyc+YZ1xunq74ODVEoXGBysga7HIxczB7ZKTNcR7Vcx/yYV4H9Pf6PuP7+rmtRRX8mBZ4Ozvr5xNYYc",
-	"OSDeBDo+rmeNMuNU6XKVfmiLEHog/TE+laym60VGlQ2R9qKaCrGfrAiX0Xhq3k8W4MjWqtyjlrJFASKV",
-	"hxcJ8gNJEPNVy7/8OCyTFE8733MJBWnzgNeSvd48q4BYycb4q7fiz23wu0j8bzz/X0y8vCJmvolu/noP",
-	"vYUa2f48fZ3pWQkYfay9ZtP30Hs+qctfFLcXxe0pZfQhJo6SwC4SqfIjr6PCRPJVIm+V8IbmKz/YTt6o",
-	"CtU+ZVItUFXmk0+vcg1sQ44O2RgLBtlctYi+76OFPXL+xerdizh60QJftMBlWmBKcXsOORJy/fESJcri",
-	"qWrphP/w/ftza46pCmHL6Kh3Jr8MX3KXSrz/32nw/I2JS0u6TELP09JopNNu/8QdheU150wduBKBmSrU",
-	"KQWQ/obBk99HqFWwtAhc6pP4GrC4ACT/8TKyb9Kfj5C0qJdVFF2STombnH2qC3+tIIN0MYoVk5XTH+qq",
-	"uL2XLV31xDf4nimt/8e4x6YpehFvnR9WijZW1nlesuGfKhv+SeLW2ZJEJQLUvNKfl1FFc1K37p81jp2q",
-	"yVsCV64q778zcF3HaPqcjWynSSBto6Rq2uJzi+cIXXl8ZePcizNj/4YQ1Q+mgb5k3T5Jxsc18ul97AFQ",
-	"jru4fkJVYCBVT/+Fgb/z8M+VgYHERUCfuPoD4ZAJwBB01EcWoYBVpyOTPZslZ3WhSvxqB/YpIq6YynNC",
-	"1XZW0yyGwVM9asKwXgeGM/iQqd4PXmMCxnPlJFclC8x3GDGxvdB8297oNuYzR2QwSfurdTF9Dlx1PYJp",
-	"B1hyRYcbV6mecaa+Ebd4+AqE+PChaYZpms8OlGgvm+tvNzfamykNZquz2dndzWox7ee/05faz4sN759E",
-	"V8gH1cfzqFRGHT+nMV6eKIP9Jfhd14WpHS/FK0rL6KXdGU+asfD5pT5NDtfPgOQSGzNdWL4hxTUkc2BT",
-	"f4xJ/GGqMAgQa3l0hhiwIUeNOLYBHSf5MnsSXJO/fo9qxP6eiaOYojnQ4zQdZF3US0J11B+1jvvdA1Vu",
-	"zYaex+Nvg0ex4YVptG/izyr/TtTomIDLi+FIjRUZm3L1KV/X64U+tzcLqtokyT9yOQTmqu3UuLf/vGS5",
-	"hGK6OllyvZ6GLKb175N4gr+QMsaFucQ7WeX78ENP4AAy0ZJKW1Mqfdm9n628WfkVpNEU6XB07KNfA/rT",
-	"2iZKzUGgi/5qdUp9Jx15KuY4B+p7NvqBvhUdM4Fto0Agp2G+j60rNRH9dRBAidJNY3VTO1OtstKVuYqd",
-	"j49/QcTgkLLquMaC0MGPUM3lKcLbFQGH/OlTc1jE7qPjJmSe3FhCBHutlkdt6E0pF3u77bft1v269fj5",
-	"8f8CAAD///20SKGypAAA",
+	"H4sIAAAAAAAC/+x92XLbuNLwq6D4/1VJzpEsWV7jqrmQZdlWvFtyMpkkdQYiIQpjEmAA0LKS8rt/hYU7",
+	"KVEZa5YsN7FILI3uRqM3NL9aNvUDShAR3Dr4agWQQR8JxNQvKAQ7Q3P5p4O4zXAgMCXWgXU1/gPZAsj3",
+	"eBwKBO7RHAgKOILMnm5YDQvLZgEUU6thEegj6yAerWEx9DnEDDnWgWAhaljcniIfymnEPJBNuWCYuNbT",
+	"U0P1egu9GjA8QC9EEgofioVAyOFWA8KmREBMEBs4RUAOIUc7+wARmzrIAXFbgJ0KINLDrQbIJPS8QwQZ",
+	"YiN6j0gRmGtGH7AEY6xaASGbAczBBBPoAcqACwUCfEpDzwGQc+SPPQSwACHHxAUcuwSKkKEY9M8hYvME",
+	"9gQCKw2qgyYw9IR1MIEeR40I9DGlHoJEwU4VwWpgUDesRl880Gq4i5d2hubXks+LgJyixxgKMUUgCMce",
+	"tkEAmQB0oh4pTp9CoTBlmqVxHcM8RdBRSDJQ/9rUaGsOIziaejfUgrkCYIm53e0Y5rg5mFD2rWDVBWko",
+	"G6EiTHccgRn0PCTkXiCSlAlcamQk+ZBAgR8QuET0eLic7fSAPT3eapz3JNmEB5RwpKSaFhw9SgQi4upM",
+	"PrL1D/nnf1r/kf8l408o86GQI2ICFUh5nDw1SkWTXIrGtpq2a9uI86acl1Gv2fU8OmteMexikp2wiHID",
+	"a/MI84ByrGep1+UcEVdM67YeqTeL255DLpoX1METjJxljX9tdiP53DzGHrqEPlqlzwj7iAvoB6WdMBHI",
+	"Rcz06kVStTmoAZemUb2mszqDyrZ60FMEnTXyFcBkQn8y1w/GXE+RzDP0juiU5ZDb0EMAPSI7lA8AQzz0",
+	"BICqNcDESNt+t3e+AfpYTBEDUPIKlxLZQQQjDqDiJYD1ecdCD72Q6oMntcJEt0Ik9K2DD1b3/PzqndWw",
+	"jvqX761PBSZuWF3HYYjzIqzmRXSwRqe+AVLN8Qj9wEPRToo1MGvn9LcR2fl8f0t8d/jltTtks06n13eu",
+	"r+93yc30fjbpXLhf5g/3+P7BSmse1v7lFt07Emx3tPkoUE/sotvZNPDf7L2ZXvR39k/n4abzAPksHB05",
+	"EvqA0QAxgfXRkdMDC2tNqzhFYifKyoecChj3SxCoH6UQeEzZXeBR6DwXJv+HvxmVuusz4VINVonM8rdV",
+	"2JSt0z1L8RkJgBJExsYE5gCCAGImkapn5VrvsyEBYyTtDmhPpQJIAUwp/ZQBSAwJcpi/l6aUVI9Y8whN",
+	"MEFOcwRdq2Epy8U6sAR0tRVTxNa9NsMKSDJdlyHoXmmaunEZTg6hB4mtBsrOC5PdW5g7YMjG3Mih+DgL",
+	"MRFbneQ4i+VobWCjOdMzLARemyNF5ThtAinaYQ7QY4Bsoek2Vnqyj5wMoT58jZROf97UOnRTjRFzlmoD",
+	"7YhpjAQ0ItI6+PCpYUkcQtPgpD+S6IDMRdLK/qCoadoxKqe0rkan/duh9fTp6dNTI7U35KIeEBtLy+5u",
+	"JBcbgxatiwKbIWnTJZ2ePlVuNvnj/zM0sQ6s/9dKbP+WOVta8gBJpslTqmE9Nl3alA+b/B4HTapwDb1m",
+	"QCWdmbbDnhJEfbWwQD5fOi2yKVNCwkwIGYPzAmeYUUuZQGlRtVhB2kZGRsZk4jGDMBQwxBGRPIIJ0NqZ",
+	"4pPcdtY8cWD1poOzoy7tnrjuoHvbPRy4g0H3kfZ6JzfD31w67f73zc4fx++OL/BVMH+4+O0wfD2bXY/O",
+	"+Dt+0v7cae/ev0W7Wzh8d92a9e/7/e3h4G37hrjkLAiOJjvbN+jL3ZkP2d7dzXi+e/olnIx25m8HVw9/",
+	"7N30P/9GruADO3vXtqc91Jtdt++nDmz98fq+3bbF7uVF/+jx5vjdf91ffikKFVHuQ8gZlXkzcvHm1WOW",
+	"UShWoQZkQouzyqdShEhNBY5pKBKGziEeJgL8QyRVE10uEaebu9v7+5vt9l7HkptKN1RKYtImu2nGkGO7",
+	"a3vWwc5WZ3en097abPw51SPufJlz/UhhMosGvRzfuaPh8cO1z28f/RP0LgjDE/Tmjt5SvHvdZ/aFFIYe",
+	"tJGPiLimHrblWm7710BK2gfEtBi2Ohubm0U6xwjjtTdkckgW9mQaTSWngg0JQY55myXxaIrAhGFEHG8O",
+	"pIRRW1F5UMyIYIKR55RwWWOp7pXDdJlCMavuXUBu2VkboXnpAZbgO4WsRk7pywKcgFcEJpl64b46x1wU",
+	"kS6fSiUmno4rA7JCKdTn088dtmyHleOoaumdums/5v290/Obw8P3dufd8Zsv4ejXCzvgwVHfn9098qOd",
+	"9/7luMM6O+FduGjtneda/GbJ4j81LI6/IOugU63U15c02WOhRNrouUrt8lIbQG461WfhZrkORfk59DFs",
+	"t7fsQP2HbtHnEHEBxtSZl6laG2BEAQ+QjSfzlBGgZFvIEYCBxA/DspPB1By8VK+DyFOPSRLE4GCGPU8q",
+	"ptgllCHn1UYGno8k83MUQ5Q2QeY0BH7IRTQF0H3kaa67XWdJrV+3kvcAEqfQ6VBxb++80NpA2EpANEBO",
+	"d3LTgSA9X/Q6t6Z868hBIVdla/8WmE0R01BO6UwdIMnqX8rHWHCj4r2SOh0XEpcb4JgyYKReQw04g0So",
+	"wJVsALaATQOMlCGNHhCbmzEagFM9PySKrHLGCZVwYeIaOA8KaNCrYgZNeXzK3bVVQGY0SNwrixz9A4Ip",
+	"Q5NfPlpTIQJ+0Gq5WEzD8YZN/RbhgW03HfTQIohOeFMyZ2vs0XHLh1wg1mpvNiGzp612p6kB3/Cdj5rr",
+	"0YXEgla+MqSCNSmteAQkTFJB4rhZZGYn4ZWEjlyw0BYhQw2gKaoaezM454bpHcCxH3oCEkRD7s3BDItp",
+	"dpQNMJKsMqFyGD0EkZQFPNQGgLTeyRzYU0hcxDfAQE8DtjrNsWyvhY0eGQL5SGkoctNmmUArr1VMkKYe",
+	"9l3AmZ0iH4OzDU3CkCNmnMbV1Gxv76LdzpZjd5z9za1tOO6M93cmNpzsb2229/acnb3tnd1N2IlJHWC7",
+	"BW2vqQ6gZsDwAxRogz+4Hy0APfHLR0vSQlEl4oQqSgs49mLWBAAYMSGmCDrpx6lXLP883U2/G879MfXM",
+	"nNHDRR0uECSYuCv0OEqEfGWv6AUrLrBVWKEZXp4M37BwM9RhNLpTo62yw1bo0NWCUwd2ZW+ggsZq47HQ",
+	"Q1xyP0Pq4Acoflo5Qyl6Vlvv3Qrg3/GVViuNC6XyFEUJdhARKqQAxvN0YPcezYGHyb12B2U6rRMLwxWW",
+	"NZxzgfwVOgyIXPKtpDkkTouytF5CHcQj2WWHjMlj1qh3Em0EiRll98CHwQYY3Jr28tSjxJuDADEp5gqq",
+	"wQkSt1J+nkI+LZxojULz02gnZZuVKR1DlVBSVFAIshHnxjEDHCgggKGDxQbo5RYbA+9IAis3bqQ1xtan",
+	"3APYVq6HjXXS/WoFMl6JKWJ8hQ49D0u9WvuxHAoIFTpaow64aE9AgVzKVJhnTB/QOld7vALwx5hAb5X2",
+	"HnSBg8hcsnn/USAiNWkV1hpMAEeiARIlw54i+z7OgWlk2svHRtVeJy5+XWXHC2zfz78VGQ6eTJDa10oY",
+	"xkEhZiwZucuSIFGCriRoVLAWQlHcgNFwys6YwgcEKCkaGiq4WW5ejFGUQRNrbVyaRUkmiARNMrECLxXX",
+	"UlOOpahmTP4eh3FQhk40s88i1c8IgQn0PKOkFUXM++Gof1GyQuohABkC6NFGgfYRTxj1pRTh6qTU9oSY",
+	"Il/DN9YKpmGntUqS9grscYTIfLXmygSKPOMRA6UOUSNF5utc4eaqis7qitHzLzF6mFYKo2dpxTlvxIcq",
+	"sGsYnMfWRjpoMadh+iRP9p0JbYylycuRKDFyI6s1z/ntx/bx4fHh8fFxkfspAwFDjg5TFnoiaU1oHarJ",
+	"EHSaM4YFKo6iHGF8Y6FR1PU4bQCHkhdC7k8XaYMciYzzRKmnSl3lgmFb5PCxUcPueh6rea8Jba/cZE7s",
+	"3ip7uSKOwVMuxF7IBfWTLJWUO9GEhjOeRKtAhSUu0XI339aagwb1A4fVsYX6YywJBdQfaGlUoO5QTyWu",
+	"yD4si5H0JaPrNB0lMp4zD4apKCvPhq91dDoJXn81eWU6Xcu6OnzT78kWmj3jPKuGpZRL02o4uh1cnvyv",
+	"f3PXPU9xrD+fYE+zbDogHkXM0yHxskD4itk38fKeN+gcDZv11Zc5l/uMUXZrck2XeJZVWxAlpi6WXykZ",
+	"Y9JlBRQhB1LSxhJ+gqX9RKJD6E9Ju067CQPcfOi09EwpeTdFDK0k5SSQ1sFmu7PdsHxptLnaiy8J4iER",
+	"q3XXdyNpncdbLokBdq8HZelDDqqVd1J/t8fQlfCWMMmLi/hJkVRtiDwLRSObcSp5J0qRzIkExSqyxwZQ",
+	"qgtwkEDMxwQBTkNmo0iBQbJlOjvvRG4zib+yzLxjteeL8+nn2XRBFfxQdlQAmcB26EEGEorkrQxjWJem",
+	"QX27eLm8GlWKmDx/pGdZTLbTpOVTozLRKgXO4uEu4ob1M55SwDZMrlYy36LUp9PMKnNsQ0I/peAGlHM8",
+	"9iKWUSTT3ZUfEAaBN4/TPLOpoimGuu3f3PWHkmAx5Yb927eDXr+UxS7SWMuCp14prs5xmoYhPWnudClw",
+	"Q9nMl9qVNSATqnOxs7Ob1yoUHmWdKOuuLGVSuZaOEbIO2qlDIHqAAmpPj8LodOtstxvWlPrUpyyYYvsU",
+	"8ikm7hHm8jh34nsKPnzUacJDFd/c3dts7+/vbuvUK6eXn4ULyqCLrhm29QNpJDgMzqCnmxQVuBjqnJTc",
+	"3S7NzssurF6f3NrrdVqEnK+F+xsFTNWbpASL9TpmEV2vT44WdTpVRa/lAI2EdvmxyxaWJ0MeYwsxnltw",
+	"mZDRQx1Cjsoj5trTRpPLCWZD5XdRkkr6d2Vzy6PiGoqpdWC1/HlLj9SSGN0QjyK5bRQ/KW6qZBELLSHT",
+	"LDNnyalSnmZZlRBbTZxywlwtJckz5vlEIH1q/D3kXTHhZe1Jcn/irkD0MpJ3pVSdhJ4HAjhXniOu93kd",
+	"WbUwC04PtzQl1Oz1qHmjcqTyFVynoJaHf2QFpVdQU25mUu0qLlVk0JnJs0sBWb23FqfVGZ9dbmOZp9rS",
+	"/vvlnhFrOZmn09ieH7qtk7F/8S7k8J17cUrv34W48+UoJI8Xoy+HoQhvLt6ej8X5ln1E9nk5dJz6qEXF",
+	"FDED6IKUsxjVNTdt7jT79oSzaOIF2WZ6rqprO3UyzYwFtdA9kMoCi26eLM8BSxG7Xv7XxJhmJflfpOs4",
+	"WBvV3jzxOVdNbbZdcdqX46yYcaCAr0qBSbb98nQ0UPkv74lO3/65R/OmriigosvR7QCdSZbErKIw2hma",
+	"K0B1lyhEhQm4Gx039012kGqh3hGq3iM/EPPaAOfAfQs97CSpgxWpR6GXDKufeLg8Ie1iHiPgALyQW1Cv",
+	"5kVVklo8UBTjSM9VcxED8rDWZawVeB26yCYGYp4qSSEomIRMXbM0+1JXyMDE/ZbYgLo6VhYZkMRqJuGB",
+	"PyXIJ/FNWsufH2MvUo1j3cB633kdOidvQ6d3+PAbPvThu0fvHxM/WKZ2TVIXhRfpP6tc34zHLD0DEsd3",
+	"4baulvkv0qFI5RCJipjkPCOpK7kqSzFQaStjD+lLiCnPnPHDZVyBys9/2u8eWQ11maxhHfXP+6O+cuF0",
+	"b3unVsO67V6e9KP/T7vD01LfynUoYgNUO1eeJ0Kxosd/AU3KCGHc/cVLn4Bj4noojWkV3s/tyPXc9yts",
+	"m/hm98Kdols9paCouceM07dE7aFpRl2oQcUNn1LLrDn/SLVfGnQxaEjWl4YvmbWUztQrsTnkU53wpbrK",
+	"nZX3bd4N+7dyM6iEEKsREalhnfXfD0s3grotWZgqSUHjiKvUOh3CL2Gq7GbZ/ePh7E3vhu2i7b33j/tD",
+	"Ph5ebk0u3S+M3r15e/9+d/fm9ezz43u7+4et72WMrYNoF68cLtPdF1PrrWyTp43qWIZ5na1XFVbQb417",
+	"Vx2NmDgV9lN5NCDyGg/VGvqfQ1XIKeuAaBrLpub9aTPuYixoyNXUK9+51hMs8uGnscarDc10M4A8FSPL",
+	"oy0dxV2Mwh71fUquGZrgx5wi0Qr008TTo3MS0opHDXII6MYqSYEcq0qtDGctkx3R4NXIvoioXsqhfhyZ",
+	"SEuHkqWmHl1SkXl6ScW1vkYcPclgvEyYDENVeKM6fmwaJEHjLPG5fp0kL2QwHr/9WlabK42+qGUZ+oz0",
+	"Lt7shFHijo4jSTUlPkdBz5RMiG5dvOA6u872IFeVRyDwDJcnidk80YJeSgGsurwqygnJ7Va7s+nYO7sT",
+	"e9fZ33R29jch2ttt78B91G6jNmqP4XjXHkNnZ3cXvu5sw53O3tbW6+29Hfh6D+6jrX21Nc3hrMR9mQTJ",
+	"8mtFjDg5UJk5iBbmIMg2JZJDHniqfykV5HFSzSc5Z50PGZ9CT+W4y2Po5SSTE05Z+YX4V/miCPF9d+/9",
+	"2WHX7fW7bdjrukf9bh93XffI3H/vmfvvg153cNPFg16ve2HaDeJ2h4fpdnfpdieZdo9Ru8G4N73f3O+8",
+	"6x8dh93Pn7cI5+zkCp62L8/av02/HO+Pw/++P3FvBvDQ7VtFrKUv7PcCSAaHb3rBm/DNl+3O2ZV/cjEk",
+	"/Sk/Oxm9+xzCXzvnn3dPptOr7Qm8en9/ftSevH53/2v4/o33eRsedqfkpHuBBzdv3GN70HenN4c73uet",
+	"7pvfrt7y2YDM7M3BydS72bvs3U23j46vtu66o0G/1+3fdG9++SUBblHJBlJlpMS39r8pSUHxTmmSQlTj",
+	"ojJFIela3P/SaqGTpEhAJDVN75RdVir73hpdJDuqfGry2dXzMeJKsqgbgZlSi4n9pFS8PBQFc2ckdb8S",
+	"SJ4aFkd2yLCY6/J2ihQ6xbIbiumSyhKR8y7yfCk3kTYrIosMXMSZmy903xdAH7iVJfrkxJThL7Hya+RM",
+	"gM/QXF9qpfcYLYTPVk00QNrL1owLHSrQza0zXgmFHqE4vcQZLg0/3faHI9C9HiiamHJ/yplqSJVgZwPc",
+	"qUtKyn0ie0Q+FWXbQ1ukMalTupUrDRLoovTNdpjVKAUWSqLHkKgRMleaHzaN7UNggK0Da2ujvbGp3B1i",
+	"qojfgrZNQyIwcVtjXSan9dV4zZ9kg9ID8QQJ2QOYHupoiy78muKIZoxMnaaYj5U9cIJEVJinkSnN+mFJ",
+	"Bc3sDFWlUOMyO/WraH7K1VLstNu5OnfGKSHhav3B87XkFkmmaKklhe8OEyzmsfZMdfDknNvPuJhsKmDp",
+	"kpxIJmTEjnYT8ND3IZtrHoiZKF6z4lh1SqsISIZprvSLfwfj5Aznq9s69DxN3i+qrVfa9wKJKXW+rW89",
+	"PsrRUv5uQSOalxFNifAfFlMNK6A61JpFjsHKQj5WN43AwAEvsyz8SusPqqoCx66++VizIm5cmnGlOsMF",
+	"1Ugdrx6eIIF9tYdVts7y6c9Nl/Jqt5vtdllwvJDLSZmfKnsFPQ+EXF0LY/papL4DibmqC70cqGPKJI2b",
+	"d9wU2qhfh/eTRiPi4pA685UkbS0fgan9VfQOFGVvSmdTZmZU3StL5qc/edjV84dmbLk6wOdKPqtbAlGZ",
+	"ssTWG+f0Uoz4xvd+Vipmzyw8FYAzA3AVS5K4cxFpmodNqbg3Da9rtrBiwd0ax0XljKqXFU9y1kz1uYKo",
+	"Klt80qSVK/ItN3HdHnEp81U6mcLd61Xm0gh5Hi7+ftg3x7B60eml1lHw5KkYM9wPrFtlS06V7tBzzJOA",
+	"JV9RJdY1JVIfI8hVpk/Syf6MkjBFgIT+WFevSBm0ggJ+jwMwVjVs5D5hyq4UFNjU81QJG3XvQhV65khU",
+	"gjmZcFRROb/dsHxMsB/66u/lWkUCLi/Cy5AIGamCw8M+FgtUGh8+akA22+12GrDNEsCWS7BC2fVapchU",
+	"yl/JTu5la+itVyKtBPoqQmhjqcHpFWoG1pFICXauQ501+SObMmGJIEonTvxr1IRGxTdmtNkQ99Rb38Vc",
+	"IJYvhYcJuLwcAo7YA7Yrv/Eh/2tymwao6Xp0rIJpz2VffJsciIoELhIFUTXNVW2HlSDKZdyUwDOIahck",
+	"9Y9MkbRMGd1/r7iKBVRP57oSNEuXeErcgYu1+1TIJas9tL6mEiaeNMd5SFeJz+7iI/X82zdyOjFjlQ35",
+	"jzMPViJ5PrxdQnTTZBJ6QOHeXFj5DnhWs0yKX8dzgFVqfqnCeoLEM7HXujSkemLxu1WQSghZXzs6QULz",
+	"w1pI+8OZfVnB3UKmrMbSjaVCwP+kzaUKgizcUzoLOHud7zvfX2rJ37DJ1kbdn9bL82yef7ji8yyGRNWO",
+	"1nUO0mlYG+u2IFZTvxSAYeBAgYn7nehgwyq5ssxkQJqKDavlIpE7bb5G9x6fap05V1E61Fo3TnwXs2i7",
+	"SyRI47Dkq39A0xhAbj5upYqwp67nboCRtPh9eK8roI8ZnXFt+Dt0RlIl7OQYE+xJw58LJB9PAJ/qQtlY",
+	"AKrDsAF0K30B0YAZF0CcjWhtNoBogFEDKE8rGN3e9RtgpP6eN8Ac8QZ43wDv+8MGeK+uBtfMRyhDbNyu",
+	"lf9y6NJAArUFEk0uGNIfb10Lk0sgtv96IC6pABMaEqdwmn+VbJfOmfugPmqVzlL78OmpcOYb1hmnP6Qw",
+	"OEqldIHB0QboejxyMXNgq8R0HdF+EfNv8jGF39Ofe/zP76q8e9RXcuDF4KKvb1yNIUcOiDeBjo/rWaPM",
+	"OPUVAJV+aIsQeiD9XUuVrKZLr0ZFQpH2oppiyx+tCJfReGrejxbgyNaq3JOWskUBIpWHnxLkO5Ig5gOx",
+	"f/lxWCYpnne+dQkFafOAl5K9Xq1VQKxkY/zVW/HHNvhdJP43nv8vJl5eEZMvztDc/PUWegs1ssN5+jrT",
+	"WgloAKvb9C301id1+U/F7afi9pwy+hgTR0lgF4lU+ZGXUWEi+SqRt0p4Q/PBLGwnb1Sxd58yqRaoDzYk",
+	"XzHmGtiGHB2yMRYMsrlqEX0qSwt75PyL1buf4uinFvhTC1ymBaYUt3XIkZDr7wApURZPVUsn/Ifv3x9b",
+	"czRfNWpGt9SqdMJUyVhrjamx2cq0ZdtnaW3af3sa7PIAUPQlKq7v0dXKP1tOvx+E4VMl8ZbhTB9F/Dr8",
+	"maxXEu76Rgv/b8zUW9JlEnqePn5HOs/8T1zKWV5k0RQ+LJEFqcq08sTV37959gs4tSr0FoEzr6SyqQGL",
+	"K57y7+8Kwl3600OSFvXS6KKqAClxk3PI6Ep3K8ggXX1lxez89EceK66rZmu1PfOV1TXdY/k+Lm5qil7F",
+	"W+e7laKNlZX8n9c/nuv6x7MkamRrcJUIUPNKf5pMVYlKlZlYa+JGqgh1CVy5MtT/zkyNOl6CT9lUjjQJ",
+	"wDj+cMnSc4vnCF15fGUTOxangv8NMdnvTAP9mWb+LClOt8inD7HLK/EZLEo0T31A4icDf+Phn6t7BImL",
+	"gD5x1YEhT23AEHTUB3qhgFWnI5M9myVndeGzCKsd2OeIuGIqzwlVzFxNsxgGT/WoCcNmHRgu4GPmcxXg",
+	"JSZgPFdRIVWjw3zDFxPbC6UubUIrySfyyGCSDtDor0dw4Kr7QEx7fJM7adzEBvSMM/V90cXDVyDEh49N",
+	"M0zTfGejRHvZ3ny9vdXeTmkwO53tzv5+Votpr/8Sa2o/Lza8fxBdIZ9FMp5HtWHq+BSN8fJMVzZ+ZnvU",
+	"dWFqx0vxTt4yeml3xrOm6Hz6WZAph+s1ILnExkx/SaEhxTUkc2BTf4xJ/FHDMAgQa3l0hhiwIUeNOJgH",
+	"HV3bMP3leKjPhN+josi/ZwKHpkoU9DhNZxUs6iWhOumPWqf97pGqL2hDz+OmplI87cuFeeOv4k/y/07U",
+	"6JiA66vhSI0VGZty9Slf18uFPrdXC8o4JdlucjkE5spL1ShUsV6yXEMxXZ0suV7PQxbT+vdJPMFfSBnj",
+	"wlzinazyffihJ3AAmWhJpa0plb7s3s+Wmq387NdoinT+Reyj3wBgMAGEmrQMDgJd5VqrU5iDCUaeCrLP",
+	"gfqAk36gywDETGDbKBDIaQD0KP/SpcmI/hwOoETpprG6qZ2pVlmt1lyJ2qenvyBicExZdVxjQejgu4zb",
+	"fkM+R0XAIX/61BwWsYfouAmZJzeWEMFBq+VRG3pTysXBfvt1u/WwaT19evq/AAAA//8GKIvh7qoAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/handlers/network.go
+++ b/handlers/network.go
@@ -1,0 +1,32 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/nspcc-dev/neofs-rest-gw/handlers/apiserver"
+	"github.com/nspcc-dev/neofs-sdk-go/client"
+)
+
+func (a *RestAPI) GetNetworkInfo(ctx echo.Context) error {
+	var prm client.PrmNetworkInfo
+
+	networkInfo, err := a.pool.NetworkInfo(ctx.Request().Context(), prm)
+	if err != nil {
+		resp := a.logAndGetErrorResponse("could not get network info", err)
+		return ctx.JSON(http.StatusBadRequest, resp)
+	}
+
+	var resp apiserver.NetworkInfoOK
+	resp.AuditFee = networkInfo.AuditFee()
+	resp.StoragePrice = networkInfo.StoragePrice()
+	resp.NamedContainerFee = networkInfo.NamedContainerFee()
+	resp.ContainerFee = networkInfo.ContainerFee()
+	resp.EpochDuration = networkInfo.EpochDuration()
+	resp.HomomorphicHashingDisabled = networkInfo.HomomorphicHashingDisabled()
+	resp.MaxObjectSize = networkInfo.MaxObjectSize()
+	resp.WithdrawalFee = networkInfo.WithdrawalFee()
+
+	ctx.Response().Header().Set(accessControlAllowOriginHeader, "*")
+	return ctx.JSON(http.StatusOK, resp)
+}

--- a/handlers/preflight.go
+++ b/handlers/preflight.go
@@ -125,3 +125,11 @@ func (a *RestAPI) OptionsByAttribute(ctx echo.Context, _ apiserver.ContainerId, 
 	ctx.Response().Header().Set(accessControlAllowMethodsHeader, allowMethods(methodGet, methodHead))
 	return ctx.NoContent(http.StatusOK)
 }
+
+// OptionsNetworkInfo handler for the network options request.
+func (a *RestAPI) OptionsNetworkInfo(ctx echo.Context) error {
+	ctx.Response().Header().Set(accessControlAllowOriginHeader, allOrigins)
+	ctx.Response().Header().Set(accessControlAllowHeadersHeader, allowHeaders)
+	ctx.Response().Header().Set(accessControlAllowMethodsHeader, allowMethods(methodGet))
+	return ctx.NoContent(http.StatusOK)
+}

--- a/spec/rest.yaml
+++ b/spec/rest.yaml
@@ -913,6 +913,45 @@ paths:
         - { }
         - BearerAuth: [ ]
         - CookieAuth: [ ]
+  /network-info:
+    get:
+      summary: "Get network settings"
+      operationId: getNetworkInfo
+      responses:
+        "200":
+          description: Network information from NeoFS.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NetworkInfoOK'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      security: [ ]
+    options:
+      operationId: optionsNetworkInfo
+      responses:
+        "200":
+          description: CORS
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+          content: { }
+      security: [ ]
 
 components:
   schemas:
@@ -1570,6 +1609,51 @@ components:
           type: string
       example:
         containerId: 5HZTn5qkRnmgSz9gSrw22CEdPPk6nQhkwf2Mgzyvkikv
+    NetworkInfoOK:
+      required:
+        - containerFee
+        - auditFee
+        - withdrawalFee
+        - namedContainerFee
+        - epochDuration
+        - maxObjectSize
+        - homomorphicHashingDisabled
+        - storagePrice
+      type: object
+      properties:
+        containerFee:
+          type: integer
+          format: uint64
+        auditFee:
+          type: integer
+          format: uint64
+        withdrawalFee:
+          type: integer
+          format: uint64
+        namedContainerFee:
+          type: integer
+          format: uint64
+        epochDuration:
+          type: integer
+          format: uint64
+        maxObjectSize:
+          type: integer
+          format: uint64
+        homomorphicHashingDisabled:
+          type: boolean
+        storagePrice:
+          type: integer
+          format: uint64
+      description: Network information from NeoFS.
+      example:
+        auditFee: 0
+        containerFee: 0
+        epochDuration: 240
+        homomorphicHashingDisabled: false
+        maxObjectSize: 67108864
+        namedContainerFee: 0
+        storagePrice: 0
+        withdrawalFee: 0
   responses:
     ObjectContentOK:
       description: Object.


### PR DESCRIPTION
It returns current network settings such as: `audit_fee`, `container_fee`, `epoch_duration`, `homomorphic_hashing_disabled`, `ir_candidate_fee`, `maintenance_mode_allowed`, `max_object_size`, `named_container_fee`, `storage_price`, `withdrawal_fee`.

Close #198.