### PR TITLE
workflows: enable builds for darwin

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        go_os: [ linux ] # darwin
+        go_os: [ linux, darwin ]
         go_arch: [ amd64, arm64 ]
 
     steps:


### PR DESCRIPTION
It works from the results we have. Docker linux/arm64 is already there.