### PR TITLE
Fix "Content-Dispositon" header

### DIFF
--- a/handlers/objects.go
+++ b/handlers/objects.go
@@ -588,6 +588,11 @@ func (a *RestAPI) setAttributes(ctx echo.Context, params setAttributeParams) str
 		attributes  = params.header.Attributes()
 	)
 
+	if paramIsPositive(params.download) {
+		dis = "attachment"
+	}
+	ctx.Response().Header().Set("Content-Disposition", dis)
+
 	if len(attributes) > 0 {
 		for _, attr := range attributes {
 			key := attr.Key()
@@ -598,10 +603,8 @@ func (a *RestAPI) setAttributes(ctx echo.Context, params setAttributeParams) str
 
 			switch key {
 			case object.AttributeFileName:
-				if paramIsPositive(params.download) {
-					dis = "attachment"
-				}
-				ctx.Response().Header().Set("Content-Disposition", dis+"; filename="+path.Base(val))
+				// Add FileName to Content-Disposition
+				ctx.Response().Header().Set("Content-Disposition", ctx.Response().Header().Get("Content-Disposition")+"; filename="+path.Base(val))
 				if params.useJSON {
 					attrJSON[key] = val
 				} else {


### PR DESCRIPTION
Add "Content-Disposition" to every GET/HEAD object response independently of the `FileName` attribute. With the new upload request, it is no longer necessary for the object to have the `FileName` attribute.