### PR TITLE
Use `external-address` directly for Swagger docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This document outlines major changes between releases.
 
 ## [Unreleased]
 
+### Updating from 0.9.0
+
+Notice that the configuration parameter `external-address` in the 
+`server.endpoints` section now also includes the scheme (http/https), not just
+the host and port. If `external-address` is not set, it will be generated from 
+`address` and `tls.enabled`.
+
 ## [0.9.0] - 2024-05-30
 
 ### Added

--- a/cmd/neofs-rest-gw/config.go
+++ b/cmd/neofs-rest-gw/config.go
@@ -144,7 +144,7 @@ func config() *viper.Viper {
 	flagSet.Duration(cfgEndpointKeepAlive, 3*time.Minute, "sets the TCP keep-alive timeouts on accepted connections. It prunes dead TCP connections ( e.g. closing laptop mid-download)")
 	flagSet.Duration(cfgEndpointReadTimeout, 30*time.Second, "maximum duration before timing out read of the request")
 	flagSet.Duration(cfgEndpointWriteTimeout, 30*time.Second, "maximum duration before timing out write of the response")
-	flagSet.String(cfgEndpointExternalAddress, "localhost:8090", "the IP and port to be shown in the API documentation")
+	flagSet.String(cfgEndpointExternalAddress, "", "the full URL address needs to be shown in the API documentation")
 
 	// init server flags
 	BindDefaultFlags(flagSet)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -56,8 +56,10 @@ server:
   endpoints:
     # The IP and port to listen on.
     - address: localhost:8081
-      # The IP and port to be shown in the API documentation.
-      external-address: localhost:8091
+      # The full URL address needs to be shown in the API documentation,
+      # including the scheme (http/https), host, and port.
+      # If not set, will be generated from `address` and `tls.enabled`.
+      external-address: https://localhost:8091
       tls:
         # Use TLS for a gRPC connection (min version is TLS 1.2).
         enabled: true
@@ -76,7 +78,7 @@ server:
       write-timeout: 30s
 
     - address: localhost:8080
-      external-address: localhost:8090
+      external-address: http://localhost:8090
       tls:
         enabled: false
         certificate: /path/to/tls/cert

--- a/docs/gate-configuration.md
+++ b/docs/gate-configuration.md
@@ -53,7 +53,7 @@ listen-limit: 0
 | `endpoint.[0].tls.certificate`  | `string`   |                  | The certificate file to use for secure connections.                                                                                                                                 |
 | `endpoint.[0].tls.key`          | `string`   |                  | The private key file to use for secure connections (without passphrase).                                                                                                            |
 | `endpoint.[0].tls.ca`           | `string`   |                  | The certificate authority certificate file to be used with mutual tls auth.                                                                                                         |
-| `endpoint.[0].external-address` | `string`   | `localhost:8090` | The IP and port to be shown in the API documentation.                                                                                                                               |
+| `endpoint.[0].external-address` | `string`   |                  | The full URL address needs to be shown in the API documentation, including the scheme (http/https), host, and port. If not set, will be generated from `address` and `tls.enabled`. |
 
 # `wallet` section
 


### PR DESCRIPTION
Now `external-address` is used straightforwardly and independently of the TLS config.

Close #217.