### PR TITLE
cmd: disable zap log sampling

### DIFF
--- a/cmd/neofs-rest-gw/config.go
+++ b/cmd/neofs-rest-gw/config.go
@@ -441,6 +441,7 @@ func newLogger(v *viper.Viper) *zap.Logger {
 	c := zap.NewProductionConfig()
 	c.Level = zap.NewAtomicLevelAt(lvl)
 	c.Encoding = "console"
+	c.Sampling = nil
 	// If the program is run in TTY, the logger adds a timestamp to its entries.
 	if term.IsTerminal(int(os.Stdout.Fd())) {
 		c.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder


### PR DESCRIPTION
Skipping log lines is not safe to be used by default. Notice that s3-authmate doesn't have this problem because of the way it constructs its settings.

See also:
 * https://github.com/nspcc-dev/neofs-node/pull/3011
 * https://github.com/nspcc-dev/neo-go/pull/598