### PR TITLE
handlers: fix panic in search, fix #300

### DIFF
--- a/handlers/objects.go
+++ b/handlers/objects.go
@@ -476,8 +476,13 @@ func (a *RestAPI) V2SearchObjects(ctx echo.Context, containerID apiserver.Contai
 		cursor string
 		opts   client.SearchObjectsOptions
 
-		searchHeader = filters[0].Header()
+		returningAttributes = make([]string, 0, len(searchFilters.Attributes)+1)
+		searchHeader        string
 	)
+	if len(filters) > 0 {
+		searchHeader = filters[0].Header()
+		returningAttributes = append(returningAttributes, searchHeader)
+	}
 
 	for i, attr := range searchFilters.Attributes {
 		if attr == searchHeader {
@@ -486,7 +491,7 @@ func (a *RestAPI) V2SearchObjects(ctx echo.Context, containerID apiserver.Contai
 		}
 	}
 
-	returningAttributes := append([]string{searchHeader}, searchFilters.Attributes...)
+	returningAttributes = append(returningAttributes, searchFilters.Attributes...)
 	if params.Cursor != nil {
 		cursor = *params.Cursor
 	}


### PR DESCRIPTION
706d7d4bf01b2b53dd6ee97bda153e624f0e0537 made this logic (that tried to deduplicate requested attributes) completely irrelevant.