### PR TITLE
workflows: use macos-latest for Mac tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -37,5 +37,5 @@ jobs:
       neofs_rest_gw_commit: ${{ github.event.inputs.neofs_rest_gw_ref }}
       tests_path: 'pytest_tests/tests/services/rest_gate'
       tests_parallel_level: 1
-      os: '[{runner: "ubuntu-latest", binary: "linux-amd64"}, {runner: "macos-14", binary: "darwin-arm64"}]'
+      os: '[{runner: "ubuntu-latest", binary: "linux-amd64"}, {runner: "macos-latest", binary: "darwin-arm64"}]'
     secrets: inherit


### PR DESCRIPTION
It's also ARM-based, but it's already macos-15. Follow https://github.com/nspcc-dev/.github/blob/6c4dff04862ad947805e82fb9b664899906c6305/gh.md.